### PR TITLE
Add REST API controllers and CRUD operations for Event and Tick…

### DIFF
--- a/src/main/java/com/neon/tamago/controller/EventController.java
+++ b/src/main/java/com/neon/tamago/controller/EventController.java
@@ -1,0 +1,52 @@
+package com.neon.tamago.controller;
+
+import com.neon.tamago.model.Event;
+import com.neon.tamago.service.EventService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/events")
+public class EventController {
+
+    @Autowired
+    private EventService eventService;
+
+    @GetMapping
+    public ResponseEntity<List<Event>> getAllEvents() {
+        List<Event> events = eventService.getAllEvents();
+        return ResponseEntity.ok(events);
+    }
+
+    @PostMapping
+    public ResponseEntity<Event> createEvent(@RequestBody Event event) {
+        Event createdEvent = eventService.saveEvent(event);
+        return ResponseEntity.ok(createdEvent);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Event> getEventById(@PathVariable Long id) {
+        return eventService.getEventById(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Event> updateEvent(@PathVariable Long id, @RequestBody Event eventDetails) {
+        return eventService.updateEvent(id, eventDetails)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteEvent(@PathVariable Long id) {
+        if (eventService.deleteEvent(id)) {
+            return ResponseEntity.noContent().build();
+        } else {
+            return ResponseEntity.notFound().build();
+        }
+    }
+}

--- a/src/main/java/com/neon/tamago/controller/TicketController.java
+++ b/src/main/java/com/neon/tamago/controller/TicketController.java
@@ -1,0 +1,52 @@
+package com.neon.tamago.controller;
+
+import com.neon.tamago.model.Ticket;
+import com.neon.tamago.service.TicketService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/tickets")
+public class TicketController {
+
+    @Autowired
+    private TicketService ticketService;
+
+    @GetMapping
+    public ResponseEntity<List<Ticket>> getAllTickets() {
+        List<Ticket> tickets = ticketService.getAllTickets();
+        return ResponseEntity.ok(tickets);
+    }
+
+    @PostMapping
+    public ResponseEntity<Ticket> createTicket(@RequestBody Ticket ticket) {
+        Ticket createdTicket = ticketService.saveTicket(ticket);
+        return ResponseEntity.ok(createdTicket);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Ticket> getTicketById(@PathVariable Long id) {
+        return ticketService.getTicketById(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Ticket> updateTicket(@PathVariable Long id, @RequestBody Ticket ticketDetails) {
+        return ticketService.updateTicket(id, ticketDetails)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteTicket(@PathVariable Long id) {
+        if (ticketService.deleteTicket(id)) {
+            return ResponseEntity.noContent().build();
+        } else {
+            return ResponseEntity.notFound().build();
+        }
+    }
+}

--- a/src/main/java/com/neon/tamago/service/EventService.java
+++ b/src/main/java/com/neon/tamago/service/EventService.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 public class EventService {
@@ -17,7 +18,31 @@ public class EventService {
         return eventRepository.findAll();
     }
 
+    public Optional<Event> getEventById(Long id) {
+        return eventRepository.findById(id);
+    }
+
     public Event saveEvent(Event event) {
         return eventRepository.save(event);
+    }
+
+    public Optional<Event> updateEvent(Long id, Event eventDetails) {
+        return eventRepository.findById(id).map(event -> {
+            event.setTitle(eventDetails.getTitle());
+            event.setDescription(eventDetails.getDescription());
+            event.setStartTime(eventDetails.getStartTime());
+            event.setEndTime(eventDetails.getEndTime());
+            event.setLocation(eventDetails.getLocation());
+            event.setCoverImageUrl(eventDetails.getCoverImageUrl());
+            event.setType(eventDetails.getType());
+            return eventRepository.save(event);
+        });
+    }
+
+    public boolean deleteEvent(Long id) {
+        return eventRepository.findById(id).map(event -> {
+            eventRepository.delete(event);
+            return true;
+        }).orElse(false);
     }
 }

--- a/src/main/java/com/neon/tamago/service/TicketService.java
+++ b/src/main/java/com/neon/tamago/service/TicketService.java
@@ -1,0 +1,46 @@
+package com.neon.tamago.service;
+
+import com.neon.tamago.model.Ticket;
+import com.neon.tamago.repository.TicketRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class TicketService {
+
+    @Autowired
+    private TicketRepository ticketRepository;
+
+    public List<Ticket> getAllTickets() {
+        return ticketRepository.findAll();
+    }
+
+    public Optional<Ticket> getTicketById(Long id) {
+        return ticketRepository.findById(id);
+    }
+
+    public Ticket saveTicket(Ticket ticket) {
+        return ticketRepository.save(ticket);
+    }
+
+    public Optional<Ticket> updateTicket(Long id, Ticket ticketDetails) {
+        return ticketRepository.findById(id).map(ticket -> {
+            ticket.setName(ticketDetails.getName());
+            ticket.setDescription(ticketDetails.getDescription());
+            ticket.setPrice(ticketDetails.getPrice());
+            ticket.setQuantity(ticketDetails.getQuantity());
+            ticket.setEvent(ticketDetails.getEvent());
+            return ticketRepository.save(ticket);
+        });
+    }
+
+    public boolean deleteTicket(Long id) {
+        return ticketRepository.findById(id).map(ticket -> {
+            ticketRepository.delete(ticket);
+            return true;
+        }).orElse(false);
+    }
+}


### PR DESCRIPTION
Event와 Ticket 엔티티에 대한 CRUD 작업을 위한 REST API 컨트롤러를 추가하고, 관련 서비스 로직을 구현했습니다. 이를 통해 클라이언트가 이벤트와 티켓 정보를 생성, 조회, 수정, 삭제할 수 있도록 기능을 제공합니다.

변경 사항:
- EventController 및 TicketController 추가
- EventService와 TicketService에 CRUD 메서드 구현